### PR TITLE
Fix/criadoperez

### DIFF
--- a/projects/counter/settings/Devnet.toml
+++ b/projects/counter/settings/Devnet.toml
@@ -1,5 +1,5 @@
 [network]
-name = "Development"
+name = "devnet"
 
 [accounts.deployer]
 mnemonic = "fetch outside black test wash cover just actual execute nice door want airport betray quantum stamp fish act pen trust portion fatigue scissors vague"

--- a/projects/counter/tests/counter_test.ts
+++ b/projects/counter/tests/counter_test.ts
@@ -1,5 +1,5 @@
 
-import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.14.0/index.ts';
+import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.24.0/index.ts';
 import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
 
 Clarinet.test({

--- a/projects/multisig-vault/settings/Devnet.toml
+++ b/projects/multisig-vault/settings/Devnet.toml
@@ -1,5 +1,5 @@
 [network]
-name = "Development"
+name = "Devnet"
 
 [accounts.deployer]
 mnemonic = "fetch outside black test wash cover just actual execute nice door want airport betray quantum stamp fish act pen trust portion fatigue scissors vague"

--- a/projects/multisig-vault/tests/multisig-vault_test.ts
+++ b/projects/multisig-vault/tests/multisig-vault_test.ts
@@ -1,4 +1,4 @@
-import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.13.0/index.ts';
+import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.24.0/index.ts';
 
 const contractName = 'multisig-vault';
 

--- a/projects/sip009-nft/settings/Devnet.toml
+++ b/projects/sip009-nft/settings/Devnet.toml
@@ -1,5 +1,5 @@
 [network]
-name = "Development"
+name = "devnet"
 
 [accounts.deployer]
 mnemonic = "fetch outside black test wash cover just actual execute nice door want airport betray quantum stamp fish act pen trust portion fatigue scissors vague"

--- a/projects/sip010-ft/settings/Devnet.toml
+++ b/projects/sip010-ft/settings/Devnet.toml
@@ -1,5 +1,5 @@
 [network]
-name = "Development"
+name = "devnet"
 
 [accounts.deployer]
 mnemonic = "fetch outside black test wash cover just actual execute nice door want airport betray quantum stamp fish act pen trust portion fatigue scissors vague"

--- a/projects/sip010-ft/tests/clarity-coin_test.ts
+++ b/projects/sip010-ft/tests/clarity-coin_test.ts
@@ -1,5 +1,5 @@
 
-import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.14.0/index.ts';
+import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.24.0/index.ts';
 import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
 
 Clarinet.test({

--- a/projects/timelocked-wallet/settings/Devnet.toml
+++ b/projects/timelocked-wallet/settings/Devnet.toml
@@ -1,5 +1,5 @@
 [network]
-name = "Development"
+name = "devnet"
 
 [accounts.deployer]
 mnemonic = "fetch outside black test wash cover just actual execute nice door want airport betray quantum stamp fish act pen trust portion fatigue scissors vague"

--- a/projects/timelocked-wallet/tests/smart-claimant_test.ts
+++ b/projects/timelocked-wallet/tests/smart-claimant_test.ts
@@ -1,5 +1,5 @@
 
-import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.14.0/index.ts';
+import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.24.0/index.ts';
 
 Clarinet.test({
 	name: "Disburses tokens once it can claim the time-locked wallet balance",

--- a/projects/timelocked-wallet/tests/timelocked-wallet_test.ts
+++ b/projects/timelocked-wallet/tests/timelocked-wallet_test.ts
@@ -1,5 +1,5 @@
 
-import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.14.0/index.ts';
+import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.24.0/index.ts';
 import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
 
 Clarinet.test({

--- a/projects/tiny-market/tests/tiny-market_test.ts
+++ b/projects/tiny-market/tests/tiny-market_test.ts
@@ -1,4 +1,4 @@
-import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.14.0/index.ts';
+import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.24.0/index.ts';
 import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
 
 const contractName = 'tiny-market';


### PR DESCRIPTION
1. Updated clarinet version to 0.24
2. When creating a new project using clarinet, default names are now "testnet", "mainnet" and "devnet". I changed the old name of "Development" to the new standard "devnet".

@MarvinJanssen should also "mocknet" be changed to "testnet"? 