### PR TITLE
docs: err-not-token-owner was defined but was never used in FT sample

### DIFF
--- a/projects/sip010-ft/contracts/clarity-coin.clar
+++ b/projects/sip010-ft/contracts/clarity-coin.clar
@@ -9,7 +9,7 @@
 
 (define-public (transfer (amount uint) (sender principal) (recipient principal) (memo (optional (buff 34))))
 	(begin
-		(asserts! (is-eq tx-sender sender) err-owner-only)
+		(asserts! (is-eq tx-sender sender) err-not-token-owner)
 		(try! (ft-transfer? clarity-coin amount sender recipient))
 		(match memo to-print (print to-print) 0x)
 		(ok true)

--- a/src/ch10-04-creating-a-sip010-ft.md
+++ b/src/ch10-04-creating-a-sip010-ft.md
@@ -104,7 +104,7 @@ conditionally call `print` if the passed `memo` is a `some`.
 ```Clarity,{"nonplayable":true}
 (define-public (transfer (amount uint) (sender principal) (recipient principal) (memo (optional (buff 34))))
 	(begin
-		(asserts! (is-eq tx-sender sender) err-owner-only)
+		(asserts! (is-eq tx-sender sender) err-not-token-owner)
 		(try! (ft-transfer? clarity-coin amount sender recipient))
 		(match memo to-print (print to-print) 0x)
 		(ok true)


### PR DESCRIPTION
I believe `err-not-token-owner` is intended to use for transfer assert.