### PR TITLE
Add distinction for control flow functions

### DIFF
--- a/src/ch06-00-control-flow.md
+++ b/src/ch06-00-control-flow.md
@@ -50,4 +50,4 @@ Another useful thing to understand with control flow functions is the
 difference between functions that end in an exclamation point (such as `unwrap!`),
 and those that do not (such as `unwrap-panic`). Those that end in an exclamation 
 point allow for arbitrary early returns from a function. Those that do not 
-terminates execution altogether and throws a runtime error. 
+terminate execution altogether and throw a runtime error. 

--- a/src/ch06-00-control-flow.md
+++ b/src/ch06-00-control-flow.md
@@ -45,3 +45,9 @@ understand! Control flow functions are absolutely necessary to produce legible
 code once your contracts become more complex. They allow you to create
 short-circuits that immediately return a value from a function, ending execution
 early and thus skipping over any expressions that might have come after.
+
+Another useful thing to understand with control flow functions is the 
+difference between functions that end in an exclamation point (such as `unwrap!`),
+and those that do not (such as `unwrap-panic`). Those that end in an exclamation 
+point allow for arbitrary early returns from a function. Those that do not 
+terminates execution altogether and throws a runtime error. 


### PR DESCRIPTION
I added a paragraph to explain the distinction between control flow functions that end with an exclamation point and those that don not. I recently learned the difference, and thought it could be helpful to know as a rule of thumb. 