### PR TITLE
Update ch07-03-interacting-with-your-contract.md

### DIFF
--- a/src/ch07-03-interacting-with-your-contract.md
+++ b/src/ch07-03-interacting-with-your-contract.md
@@ -118,3 +118,12 @@ changing the sender a couple of times and by specifying principals for
 
 Congratulations, you just made and manually tested your first Clarity smart
 contract.
+
+## A word on a contract's *context*
+
+In the previous section we describe changing the contract's context. The context
+refers to the current state of the contract runtime environment during execution,
+including the value of `tx-sender` and the local binding of symbols to values in
+the scope of a `let` expression. This information is important because it
+determines how the contract will behave and what actions it will take as it is
+executed. 


### PR DESCRIPTION
Added technical definition of *context* with respect to Clarity contracts, per a Discord message from Terje, OKed by @MarvinJanssen