### PR TITLE
fix: remove unnecessary async

### DIFF
--- a/projects/timelocked-wallet/tests/timelocked-wallet_test.ts
+++ b/projects/timelocked-wallet/tests/timelocked-wallet_test.ts
@@ -4,7 +4,7 @@ import { assertEquals } from 'https://deno.land/std@0.125.0/testing/asserts.ts';
 
 Clarinet.test({
 	name: "Allows the contract owner to lock an amount",
-	async fn(chain: Chain, accounts: Map<string, Account>) {
+	fn(chain: Chain, accounts: Map<string, Account>) {
 		const deployer = accounts.get('deployer')!;
 		const beneficiary = accounts.get('wallet_1')!;
 		const amount = 10;
@@ -21,7 +21,7 @@ Clarinet.test({
 
 Clarinet.test({
 	name: "Does not allow anyone else to lock an amount",
-	async fn(chain: Chain, accounts: Map<string, Account>) {
+	fn(chain: Chain, accounts: Map<string, Account>) {
 		const accountA = accounts.get('wallet_1')!;
 		const beneficiary = accounts.get('wallet_2')!;
 		const block = chain.mineBlock([
@@ -35,7 +35,7 @@ Clarinet.test({
 
 Clarinet.test({
 	name: "Cannot lock more than once",
-	async fn(chain: Chain, accounts: Map<string, Account>) {
+	fn(chain: Chain, accounts: Map<string, Account>) {
 		const deployer = accounts.get('deployer')!;
 		const beneficiary = accounts.get('wallet_1')!;
 		const amount = 10;
@@ -58,7 +58,7 @@ Clarinet.test({
 
 Clarinet.test({
 	name: "Unlock height cannot be in the past",
-	async fn(chain: Chain, accounts: Map<string, Account>) {
+	fn(chain: Chain, accounts: Map<string, Account>) {
 		const deployer = accounts.get('deployer')!;
 		const beneficiary = accounts.get('wallet_1')!;
 		const targetBlockHeight = 10;
@@ -81,7 +81,7 @@ Clarinet.test({
 
 Clarinet.test({
 	name: "Allows the beneficiary to bestow the right to claim to someone else",
-	async fn(chain: Chain, accounts: Map<string, Account>) {
+	fn(chain: Chain, accounts: Map<string, Account>) {
 		const deployer = accounts.get('deployer')!;
 		const beneficiary = accounts.get('wallet_1')!;
 		const newBeneficiary = accounts.get('wallet_2')!;
@@ -97,7 +97,7 @@ Clarinet.test({
 
 Clarinet.test({
 	name: "Does not allow anyone else to bestow the right to claim to someone else (not even the contract owner)",
-	async fn(chain: Chain, accounts: Map<string, Account>) {
+	fn(chain: Chain, accounts: Map<string, Account>) {
 		const deployer = accounts.get('deployer')!;
 		const beneficiary = accounts.get('wallet_1')!;
 		const accountA = accounts.get('wallet_3')!;
@@ -114,7 +114,7 @@ Clarinet.test({
 
 Clarinet.test({
 	name: "Allows the beneficiary to claim the balance when the block-height is reached",
-	async fn(chain: Chain, accounts: Map<string, Account>) {
+	fn(chain: Chain, accounts: Map<string, Account>) {
 		const deployer = accounts.get('deployer')!;
 		const beneficiary = accounts.get('wallet_1')!;
 		const targetBlockHeight = 10;
@@ -138,7 +138,7 @@ Clarinet.test({
 
 Clarinet.test({
 	name: "Does not allow the beneficiary to claim the balance before the block-height is reached",
-	async fn(chain: Chain, accounts: Map<string, Account>) {
+	fn(chain: Chain, accounts: Map<string, Account>) {
 		const deployer = accounts.get('deployer')!;
 		const beneficiary = accounts.get('wallet_1')!;
 		const targetBlockHeight = 10;
@@ -162,7 +162,7 @@ Clarinet.test({
 
 Clarinet.test({
 	name: "Does not allow anyone else to claim the balance when the block-height is reached",
-	async fn(chain: Chain, accounts: Map<string, Account>) {
+	fn(chain: Chain, accounts: Map<string, Account>) {
 		const deployer = accounts.get('deployer')!;
 		const beneficiary = accounts.get('wallet_1')!;
 		const other = accounts.get('wallet_2')!;

--- a/src/ch08-01-time-locked-wallet.md
+++ b/src/ch08-01-time-locked-wallet.md
@@ -268,16 +268,21 @@ We start by writing the four tests that cover the different cases of `lock`.
 ```typescript
 Clarinet.test({
   name: "Allows the contract owner to lock an amount",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     const deployer = accounts.get("deployer")!;
     const beneficiary = accounts.get("wallet_1")!;
     const amount = 10;
     const block = chain.mineBlock([
-      Tx.contractCall("timelocked-wallet", "lock", [
-        types.principal(beneficiary.address),
-        types.uint(10),
-        types.uint(amount),
-      ], deployer.address),
+      Tx.contractCall(
+        "timelocked-wallet",
+        "lock",
+        [
+          types.principal(beneficiary.address),
+          types.uint(10),
+          types.uint(amount),
+        ],
+        deployer.address
+      ),
     ]);
 
     // The lock should be successful.
@@ -286,22 +291,23 @@ Clarinet.test({
     block.receipts[0].events.expectSTXTransferEvent(
       amount,
       deployer.address,
-      `${deployer.address}.timelocked-wallet`,
+      `${deployer.address}.timelocked-wallet`
     );
   },
 });
 
 Clarinet.test({
   name: "Does not allow anyone else to lock an amount",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     const accountA = accounts.get("wallet_1")!;
     const beneficiary = accounts.get("wallet_2")!;
     const block = chain.mineBlock([
-      Tx.contractCall("timelocked-wallet", "lock", [
-        types.principal(beneficiary.address),
-        types.uint(10),
-        types.uint(10),
-      ], accountA.address),
+      Tx.contractCall(
+        "timelocked-wallet",
+        "lock",
+        [types.principal(beneficiary.address), types.uint(10), types.uint(10)],
+        accountA.address
+      ),
     ]);
 
     // Should return err-owner-only (err u100).
@@ -311,21 +317,31 @@ Clarinet.test({
 
 Clarinet.test({
   name: "Cannot lock more than once",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     const deployer = accounts.get("deployer")!;
     const beneficiary = accounts.get("wallet_1")!;
     const amount = 10;
     const block = chain.mineBlock([
-      Tx.contractCall("timelocked-wallet", "lock", [
-        types.principal(beneficiary.address),
-        types.uint(10),
-        types.uint(amount),
-      ], deployer.address),
-      Tx.contractCall("timelocked-wallet", "lock", [
-        types.principal(beneficiary.address),
-        types.uint(10),
-        types.uint(amount),
-      ], deployer.address),
+      Tx.contractCall(
+        "timelocked-wallet",
+        "lock",
+        [
+          types.principal(beneficiary.address),
+          types.uint(10),
+          types.uint(amount),
+        ],
+        deployer.address
+      ),
+      Tx.contractCall(
+        "timelocked-wallet",
+        "lock",
+        [
+          types.principal(beneficiary.address),
+          types.uint(10),
+          types.uint(amount),
+        ],
+        deployer.address
+      ),
     ]);
 
     // The first lock worked and STX were transferred.
@@ -333,7 +349,7 @@ Clarinet.test({
     block.receipts[0].events.expectSTXTransferEvent(
       amount,
       deployer.address,
-      `${deployer.address}.timelocked-wallet`,
+      `${deployer.address}.timelocked-wallet`
     );
 
     // The second lock fails with err-already-locked (err u101).
@@ -346,7 +362,7 @@ Clarinet.test({
 
 Clarinet.test({
   name: "Unlock height cannot be in the past",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     const deployer = accounts.get("deployer")!;
     const beneficiary = accounts.get("wallet_1")!;
     const targetBlockHeight = 10;
@@ -356,11 +372,16 @@ Clarinet.test({
     chain.mineEmptyBlockUntil(targetBlockHeight + 1);
 
     const block = chain.mineBlock([
-      Tx.contractCall("timelocked-wallet", "lock", [
-        types.principal(beneficiary.address),
-        types.uint(targetBlockHeight),
-        types.uint(amount),
-      ], deployer.address),
+      Tx.contractCall(
+        "timelocked-wallet",
+        "lock",
+        [
+          types.principal(beneficiary.address),
+          types.uint(targetBlockHeight),
+          types.uint(amount),
+        ],
+        deployer.address
+      ),
     ]);
 
     // The second lock fails with err-unlock-in-past (err u102).
@@ -381,19 +402,23 @@ successfully call `bestow`.
 ```typescript
 Clarinet.test({
   name: "Allows the beneficiary to bestow the right to claim to someone else",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  fn(chain: Chain, accounts: Map<string, Account>) {
     const deployer = accounts.get("deployer")!;
     const beneficiary = accounts.get("wallet_1")!;
     const newBeneficiary = accounts.get("wallet_2")!;
     const block = chain.mineBlock([
-      Tx.contractCall("timelocked-wallet", "lock", [
-        types.principal(beneficiary.address),
-        types.uint(10),
-        types.uint(10),
-      ], deployer.address),
-      Tx.contractCall("timelocked-wallet", "bestow", [
-        types.principal(newBeneficiary.address),
-      ], beneficiary.address),
+      Tx.contractCall(
+        "timelocked-wallet",
+        "lock",
+        [types.principal(beneficiary.address), types.uint(10), types.uint(10)],
+        deployer.address
+      ),
+      Tx.contractCall(
+        "timelocked-wallet",
+        "bestow",
+        [types.principal(newBeneficiary.address)],
+        beneficiary.address
+      ),
     ]);
 
     // Both results are (ok true).
@@ -402,30 +427,36 @@ Clarinet.test({
 });
 
 Clarinet.test({
-  name:
-    "Does not allow anyone else to bestow the right to claim to someone else (not even the contract owner)",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  name: "Does not allow anyone else to bestow the right to claim to someone else (not even the contract owner)",
+  fn(chain: Chain, accounts: Map<string, Account>) {
     const deployer = accounts.get("deployer")!;
     const beneficiary = accounts.get("wallet_1")!;
     const accountA = accounts.get("wallet_3")!;
     const block = chain.mineBlock([
-      Tx.contractCall("timelocked-wallet", "lock", [
-        types.principal(beneficiary.address),
-        types.uint(10),
-        types.uint(10),
-      ], deployer.address),
-      Tx.contractCall("timelocked-wallet", "bestow", [
-        types.principal(deployer.address),
-      ], deployer.address),
-      Tx.contractCall("timelocked-wallet", "bestow", [
-        types.principal(accountA.address),
-      ], accountA.address),
+      Tx.contractCall(
+        "timelocked-wallet",
+        "lock",
+        [types.principal(beneficiary.address), types.uint(10), types.uint(10)],
+        deployer.address
+      ),
+      Tx.contractCall(
+        "timelocked-wallet",
+        "bestow",
+        [types.principal(deployer.address)],
+        deployer.address
+      ),
+      Tx.contractCall(
+        "timelocked-wallet",
+        "bestow",
+        [types.principal(accountA.address)],
+        accountA.address
+      ),
     ]);
 
     // All but the first call fails with err-beneficiary-only (err u104).
-    block.receipts.slice(1).map(({ result }) =>
-      result.expectErr().expectUint(104)
-    );
+    block.receipts
+      .slice(1)
+      .map(({ result }) => result.expectErr().expectUint(104));
   },
 });
 ```
@@ -437,19 +468,23 @@ that only the beneficiary can claim.
 
 ```typescript
 Clarinet.test({
-  name:
-    "Allows the beneficiary to claim the balance when the block-height is reached",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  name: "Allows the beneficiary to claim the balance when the block-height is reached",
+  fn(chain: Chain, accounts: Map<string, Account>) {
     const deployer = accounts.get("deployer")!;
     const beneficiary = accounts.get("wallet_1")!;
     const targetBlockHeight = 10;
     const amount = 10;
     chain.mineBlock([
-      Tx.contractCall("timelocked-wallet", "lock", [
-        types.principal(beneficiary.address),
-        types.uint(targetBlockHeight),
-        types.uint(amount),
-      ], deployer.address),
+      Tx.contractCall(
+        "timelocked-wallet",
+        "lock",
+        [
+          types.principal(beneficiary.address),
+          types.uint(targetBlockHeight),
+          types.uint(amount),
+        ],
+        deployer.address
+      ),
     ]);
 
     // Advance the chain until the unlock height.
@@ -464,25 +499,29 @@ Clarinet.test({
     block.receipts[0].events.expectSTXTransferEvent(
       amount,
       `${deployer.address}.timelocked-wallet`,
-      beneficiary.address,
+      beneficiary.address
     );
   },
 });
 
 Clarinet.test({
-  name:
-    "Does not allow the beneficiary to claim the balance before the block-height is reached",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  name: "Does not allow the beneficiary to claim the balance before the block-height is reached",
+  fn(chain: Chain, accounts: Map<string, Account>) {
     const deployer = accounts.get("deployer")!;
     const beneficiary = accounts.get("wallet_1")!;
     const targetBlockHeight = 10;
     const amount = 10;
     chain.mineBlock([
-      Tx.contractCall("timelocked-wallet", "lock", [
-        types.principal(beneficiary.address),
-        types.uint(targetBlockHeight),
-        types.uint(amount),
-      ], deployer.address),
+      Tx.contractCall(
+        "timelocked-wallet",
+        "lock",
+        [
+          types.principal(beneficiary.address),
+          types.uint(targetBlockHeight),
+          types.uint(amount),
+        ],
+        deployer.address
+      ),
     ]);
 
     // Advance the chain until the unlock height minus one.
@@ -499,20 +538,24 @@ Clarinet.test({
 });
 
 Clarinet.test({
-  name:
-    "Does not allow anyone else to claim the balance when the block-height is reached",
-  async fn(chain: Chain, accounts: Map<string, Account>) {
+  name: "Does not allow anyone else to claim the balance when the block-height is reached",
+  fn(chain: Chain, accounts: Map<string, Account>) {
     const deployer = accounts.get("deployer")!;
     const beneficiary = accounts.get("wallet_1")!;
     const other = accounts.get("wallet_2")!;
     const targetBlockHeight = 10;
     const amount = 10;
     chain.mineBlock([
-      Tx.contractCall("timelocked-wallet", "lock", [
-        types.principal(beneficiary.address),
-        types.uint(targetBlockHeight),
-        types.uint(amount),
-      ], deployer.address),
+      Tx.contractCall(
+        "timelocked-wallet",
+        "lock",
+        [
+          types.principal(beneficiary.address),
+          types.uint(targetBlockHeight),
+          types.uint(amount),
+        ],
+        deployer.address
+      ),
     ]);
 
     // Advance the chain until the unlock height.


### PR DESCRIPTION
This avoids deno-lint from tagging the test function