### PR TITLE
Update multiplayer counter contract description for get-count functio…

### DIFF
--- a/src/ch07-01-creating-a-new-project.md
+++ b/src/ch07-01-creating-a-new-project.md
@@ -5,7 +5,7 @@ contract will have the following features:
 
 - A data store that keeps a counter per principal.
 - A public function `count-up` that increments the counter for `tx-sender`.
-- A public function `get-count` that returns the current counter value for the
+- A read-only function `get-count` that returns the current counter value for the
   passed principal.
 
 Once the contract is finished, we will look at how we can interact with the


### PR DESCRIPTION
…n to read only

Updated the description of the 'multiplayer counter contract' project in ch07-01-creating-a-new-project.md to clarify that the `get-count` function is a read-only function.