### PR TITLE
Changed description of `get-count` function to read only and fixed minor typo

### DIFF
--- a/src/ch06-03-unwrap-flavours.md
+++ b/src/ch06-03-unwrap-flavours.md
@@ -5,7 +5,7 @@ in a slightly different manner.
 
 `unwrap!` takes an `optional` or `response` as the first input and a throw value
 as the second input. It follows the same unwrapping behaviour of `try!` , but
-instead of propagating the the `none` or the `err` it will return the the throw
+instead of propagating the `none` or the `err` it will return the the throw
 value instead.
 
 ```Clarity

--- a/src/ch07-01-creating-a-new-project.md
+++ b/src/ch07-01-creating-a-new-project.md
@@ -5,7 +5,7 @@ contract will have the following features:
 
 - A data store that keeps a counter per principal.
 - A public function `count-up` that increments the counter for `tx-sender`.
-- A public function `get-count` that returns the current counter value for the
+- A read-only function `get-count` that returns the current counter value for the
   passed principal.
 
 Once the contract is finished, we will look at how we can interact with the


### PR DESCRIPTION
Updated the description of the 'multiplayer counter contract' project in ch07-01-creating-a-new-project.md to clarify that the `get-count` is a read-only function. And fixed minor typo in ch06-03-unwrap-flavours.md