### PR TITLE
Updated link label and replaced uneven with odd

### DIFF
--- a/src/ch06-00-control-flow.md
+++ b/src/ch06-00-control-flow.md
@@ -29,12 +29,12 @@ great smart contract developer. The names of the control flow functions are:
 
 Up until now, we used `if` expressions to either return an `ok` or an `err`
 response. Recall the return portion of the `count-even` function in the chapter
-on [public function](ch05-01-public-functions.md):
+on [public functions](ch05-01-public-functions.md):
 
 ```Clarity,{"nonplayable":true}
 (if (is-eq (mod number u2) u0)
 	(ok "the number is even")
-	(err "the number is uneven")
+	(err "the number is odd")
 )
 ```
 


### PR DESCRIPTION
Updated link label to accurately reflect chapter section. 
Replaced **uneven** with **odd** because "odd" is the standard mathematical term used to describe integers that are not divisible by 2. 