### PR TITLE
Switch tx-sender to contract-caller

### DIFF
--- a/src/ch03-00-keywords.md
+++ b/src/ch03-00-keywords.md
@@ -39,6 +39,12 @@ special function `as-contract` was used to shift the sending context.
 (as-contract tx-sender)
 ```
 
+Note that using `tx-sender` as a check for permission to call a contract can expose you to a vulnerability where a malicious contract could trick a user into calling it instead of the intended contract, but the `tx-sender` check would pass, since it returns the original contract caller.
+
+For example, I think I am calling contract A, but am socially engineered into calling contract b instead. Contract b then calls into contract a but passes different parameters. Any permission checks in contract A will pass since I am the original `tx-sender`.
+
+For this reason, it is recommended to instead use `contract-caller`, described below.
+
 ## contract-caller
 
 Contains the principal that called the function. It can be a standard principal
@@ -50,3 +56,7 @@ previous contract in the chain.
 ```Clarity
 contract-caller
 ```
+
+In the above example, contract A would not be vulnerable to this exploit, since a permission check using `contract-caller` would result in the malicious contract, failing the permission check.
+
+Don't worry if this isn't fully clear now. It will become clear as we go through examples in the book.

--- a/src/ch05-02-private-functions.md
+++ b/src/ch05-02-private-functions.md
@@ -9,7 +9,7 @@ similar expressions in multiple locations, then it is worth considering turning
 those expressions into a separate private function.
 
 The contract bellow allows only the contract owner to update the `recipients`
-map via two public functions. Instead of having to repeat the `tx-sender` check,
+map via two public functions. Instead of having to repeat the `contract-caller` check,
 it is _abstracted away_ to its own private function called `is-valid-caller`.
 
 ```Clarity
@@ -24,7 +24,7 @@ it is _abstracted away_ to its own private function called `is-valid-caller`.
 (define-map recipients principal uint)
 
 (define-private (is-valid-caller)
-	(is-eq contract-owner tx-sender)
+	(is-eq contract-owner contract-caller)
 )
 
 (define-public (add-recipient (recipient principal) (amount uint))
@@ -54,7 +54,7 @@ number of smaller private functions can alleviate these issues.
 Private functions may return any type, including responses, although returning
 an `ok` or an `err` will have no effect on the materialised state of the chain.
 
-```Clarity,{"validation_code":"(asserts! (not (is-valid-caller tx-sender)) \"That does not seem right, try again...\")\n(asserts! (is-valid-caller 'ST20ATRN26N9P05V2F1RHFRV24X8C8M3W54E427B2) \"Almost there, try again!\")","hint": "Write a private function called 'is-valid-caller' that returns true or false based on whether the tx-sender is one of the authorised principals."}
+```Clarity,{"validation_code":"(asserts! (not (is-valid-caller contract-caller)) "That does not seem right, try again...")\n(asserts! (is-valid-caller 'ST20ATRN26N9P05V2F1RHFRV24X8C8M3W54E427B2) "Almost there, try again!")","hint": "Write a private function called 'is-valid-caller' that returns true or false based on whether the contract-caller is one of the authorised principals."}
 (define-constant err-invalid-caller (err u1))
 
 (define-map authorised-callers principal bool)
@@ -68,7 +68,7 @@ an `ok` or an `err` will have no effect on the materialised state of the chain.
 )
 
 (define-public (delete-recipient (recipient principal))
-	(if (is-valid-caller tx-sender)
+	(if (is-valid-caller contract-caller)
 		(ok (map-delete recipients recipient))
 		err-invalid-caller
 	)

--- a/src/ch06-01-asserts.md
+++ b/src/ch06-01-asserts.md
@@ -55,7 +55,7 @@ name—that certain values are what you expect them to be.
 
 Remember that `is-valid-caller` function in the
 [chapter on private functions](ch05-02-private-functions.md)? The example used
-an `if` function to only allow the action if the `tx-sender` was equal to the
+an `if` function to only allow the action if the `contract-caller` was equal to the
 principal that deployed the contract. Let us now rewrite that contract to use
 `asserts!` instead:
 
@@ -71,12 +71,12 @@ principal that deployed the contract. Let us now rewrite that contract to use
 (define-map recipients principal uint)
 
 (define-private (is-valid-caller)
-	(is-eq contract-owner tx-sender)
+	(is-eq contract-owner contract-caller)
 )
 
 (define-public (add-recipient (recipient principal) (amount uint))
 	(begin
-		;; Assert the tx-sender is valid.
+		;; Assert the contract-caller is valid.
 		(asserts! (is-valid-caller) err-invalid-caller)
 		(ok (map-set recipients recipient amount))
 	)
@@ -84,7 +84,7 @@ principal that deployed the contract. Let us now rewrite that contract to use
 
 (define-public (delete-recipient (recipient principal))
 	(begin
-		;; Assert the tx-sender is valid.
+		;; Assert the contract-caller is valid.
 		(asserts! (is-valid-caller) err-invalid-caller)
 		(ok (map-delete recipients recipient))
 	)

--- a/src/ch06-03-unwrap-flavours.md
+++ b/src/ch06-03-unwrap-flavours.md
@@ -75,7 +75,7 @@ not. It makes working with [maps](ch04-03-maps.md) and
 			;; The magic happens here.
 			(listing (unwrap! (get-listing id) err-unknown-listing))
 		)
-		(asserts! (is-eq tx-sender (get maker listing)) err-not-the-maker)
+		(asserts! (is-eq contract-caller (get maker listing)) err-not-the-maker)
 		(map-set listings {id: id} (merge listing {name: new-name}))
 		(ok true)
 	)

--- a/src/ch08-03-multi-signature-vault.md
+++ b/src/ch08-03-multi-signature-vault.md
@@ -90,7 +90,7 @@ guards in place.
 ```Clarity,{"nonplayable":true}
 (define-public (start (new-members (list 100 principal)) (new-votes-required uint))
 	(begin
-		(asserts! (is-eq tx-sender contract-owner) err-owner-only)
+		(asserts! (is-eq contract-caller contract-owner) err-owner-only)
 		(asserts! (is-eq (len (var-get members)) u0) err-already-locked)
 		(asserts! (>= (len new-members) new-votes-required) err-more-votes-than-members-required)
 		(var-set members new-members)
@@ -103,15 +103,15 @@ guards in place.
 ### Implementing vote
 
 The vote function is even more straightforward. All we have to do is make sure
-the `tx-sender` is one of the members. We can do that by checking if the
-`tx-sender` is present in the members list by using the built-in `index-of`
+the `contract-caller` is one of the members. We can do that by checking if the
+`contract-caller` is present in the members list by using the built-in `index-of`
 function. It returns an [optional](ch02-03-composite-types.md#optionals) type,
 so we can simply check if it returns a `(some ...)`, rather than a `none`.
 
 ```Clarity,{"nonplayable":true}
 (define-public (vote (recipient principal) (decision bool))
 	(begin
-		(asserts! (is-some (index-of (var-get members) tx-sender)) err-not-a-member)
+		(asserts! (is-some (index-of (var-get members) contract-caller)) err-not-a-member)
 		(ok (map-set votes {member: tx-sender, recipient: recipient} {decision: decision}))
 	)
 )

--- a/src/ch10-02-creating-a-sip009-nft.md
+++ b/src/ch10-02-creating-a-sip009-nft.md
@@ -178,12 +178,12 @@ The `get-owner` function only has to wrap the built-in `nft-get-owner?`.
 #### transfer
 
 The `transfer` function should assert that the `sender` is equal to the
-`tx-sender` to prevent principals from transferring tokens they do not own.
+`contract-caller` to prevent principals from transferring tokens they do not own.
 
 ```Clarity,{"nonplayable":true}
 (define-public (transfer (token-id uint) (sender principal) (recipient principal))
 	(begin
-		(asserts! (is-eq tx-sender sender) err-not-token-owner)
+		(asserts! (is-eq contract-caller sender) err-not-token-owner)
 		(nft-transfer? stacksies token-id sender recipient)
 	)
 )
@@ -192,7 +192,7 @@ The `transfer` function should assert that the `sender` is equal to the
 #### mint
 
 We will also add a convenience function to mint new tokens. A simple guard to
-check if the `tx-sender` is equal to the `contract-owner` constant will prevent
+check if the `contract-caller` is equal to the `contract-owner` constant will prevent
 others from minting new tokens. The function will increment the last token ID
 and then mint a new token for the recipient.
 
@@ -202,7 +202,7 @@ and then mint a new token for the recipient.
 		(
 			(token-id (+ (var-get last-token-id) u1))
 		)
-		(asserts! (is-eq tx-sender contract-owner) err-owner-only)
+		(asserts! (is-eq contract-caller contract-owner) err-owner-only)
 		(try! (nft-mint? stacksies token-id recipient))
 		(var-set last-token-id token-id)
 		(ok token-id)

--- a/src/ch10-04-creating-a-sip010-ft.md
+++ b/src/ch10-04-creating-a-sip010-ft.md
@@ -97,14 +97,14 @@ two error codes:
 #### transfer
 
 The `transfer` function should assert that the `sender` is equal to the
-`tx-sender` to prevent principals from transferring tokens they do not own. It
+`contract-caller` to prevent principals from transferring tokens they do not own. It
 should also unwrap and print the `memo` if it is not `none`. We use `match` to
 conditionally call `print` if the passed `memo` is a `some`.
 
 ```Clarity,{"nonplayable":true}
 (define-public (transfer (amount uint) (sender principal) (recipient principal) (memo (optional (buff 34))))
 	(begin
-		(asserts! (is-eq tx-sender sender) err-not-token-owner)
+		(asserts! (is-eq contract-caller sender) err-not-token-owner)
 		(try! (ft-transfer? clarity-coin amount sender recipient))
 		(match memo to-print (print to-print) 0x)
 		(ok true)
@@ -196,7 +196,7 @@ that only the contract deployer can successfully call.
 ```Clarity,{"nonplayable":true}
 (define-public (mint (amount uint) (recipient principal))
 	(begin
-		(asserts! (is-eq tx-sender contract-owner) err-owner-only)
+		(asserts! (contract-caller contract-owner) err-owner-only)
 		(ft-mint? clarity-coin amount recipient)
 	)
 )

--- a/src/ch11-01-setup.md
+++ b/src/ch11-01-setup.md
@@ -15,7 +15,7 @@ example:
 ```Clarity,{"nonplayable":true}
 (define-public (mint (recipient principal))
 	(let ((token-id (+ (var-get token-id-nonce) u1)))
-		(asserts! (is-eq tx-sender contract-owner) err-owner-only)
+		(asserts! (is-eq contract-caller contract-owner) err-owner-only)
 		(try! (nft-mint? stacksies token-id recipient))
 		(asserts! (var-set token-id-nonce token-id) err-token-id-failure)
 		(ok token-id)
@@ -32,7 +32,7 @@ function that only the contract deployer can call.
 ```Clarity,{"nonplayable":true}
 (define-public (mint (amount uint) (recipient principal))
 	(begin
-		(asserts! (is-eq tx-sender contract-owner) err-owner-only)
+		(asserts! (is-eq contract-caller contract-owner) err-owner-only)
 		(ft-mint? amazing-coin amount recipient)
 	)
 )
@@ -55,11 +55,11 @@ learned. We also define a constant for the contract owner.
 We will then think about the various error states that exist in our marketplace.
 The act of listing an NFT may fail under a number of circumstances; namely, the
 expiry block height is in the past, or the listing price is zero (we will not
-allow free listings). Additionally, there is the possibility that a user may try 
-to list an NFT for sale without actually owning it. However, this issue will 
-be addressed by the NFT contract's built-in safeguards. You may remember that 
+allow free listings). Additionally, there is the possibility that a user may try
+to list an NFT for sale without actually owning it. However, this issue will
+be addressed by the NFT contract's built-in safeguards. You may remember that
 the built-in NFT functions fail with an
-error code if the NFT does not exist or if it is not owned by `tx-sender`. We
+error code if the NFT does not exist or if it is not owned by `contract-caller`. We
 will simply propagate those errors using
 [control flow functions](ch06-00-control-flow.md). We therefore only define two
 listing error codes:
@@ -161,7 +161,7 @@ public functions later.
 
 (define-public (set-whitelisted (asset-contract principal) (whitelisted bool))
 	(begin
-		(asserts! (is-eq contract-owner tx-sender) err-unauthorised)
+		(asserts! (is-eq contract-caller contract-owner) err-unauthorised)
 		(ok (map-set whitelisted-asset-contracts asset-contract whitelisted))
 	)
 )

--- a/src/ch11-02-listing-and-cancelling.md
+++ b/src/ch11-02-listing-and-cancelling.md
@@ -88,7 +88,7 @@ reference. The rest can be read from the data map.
 		(listing (unwrap! (map-get? listings listing-id) err-unknown-listing))
 		(maker (get maker listing))
 		)
-		(asserts! (is-eq maker tx-sender) err-unauthorised)
+		(asserts! (is-eq maker contract-caller) err-unauthorised)
 		(asserts! (is-eq (get nft-asset-contract listing) (contract-of nft-asset-contract)) err-nft-asset-mismatch)
 		(map-delete listings listing-id)
 		(as-contract (transfer-nft nft-asset-contract (get token-id listing) tx-sender maker))

--- a/src/ch11-03-fulfilling-listings.md
+++ b/src/ch11-03-fulfilling-listings.md
@@ -27,8 +27,8 @@ and listing tuple as parameters in order to validate all conditions.
 ```Clarity,{"nonplayable":true}
 (define-private (assert-can-fulfil (nft-asset-contract principal) (payment-asset-contract (optional principal)) (listing {maker: principal, taker: (optional principal), token-id: uint, nft-asset-contract: principal, expiry: uint, price: uint, payment-asset-contract: (optional principal)}))
 	(begin
-		(asserts! (not (is-eq (get maker listing) tx-sender)) err-maker-taker-equal)
-		(asserts! (match (get taker listing) intended-taker (is-eq intended-taker tx-sender) true) err-unintended-taker)
+		(asserts! (not (is-eq (get maker listing) contract-caller)) err-maker-taker-equal)
+		(asserts! (match (get taker listing) intended-taker (is-eq intended-taker contract-caller) true) err-unintended-taker)
 		(asserts! (< block-height (get expiry listing)) err-listing-expired)
 		(asserts! (is-eq (get nft-asset-contract listing) nft-asset-contract) err-nft-asset-mismatch)
 		(asserts! (is-eq (get payment-asset-contract listing) payment-asset-contract) err-payment-asset-mismatch)

--- a/src/ch13-01-coding-style.md
+++ b/src/ch13-01-coding-style.md
@@ -69,7 +69,7 @@ some prior variables.
 )
 ```
 
-### Avoid *-panic functions
+### Avoid \*-panic functions
 
 There are multiple ways to unwrap values, but `unwrap-panic` and
 `unwrap-err-panic` should generally be avoided. They abort the call with a
@@ -88,7 +88,7 @@ below.
 			;; Emits an error value when the unwrap fails.
 			(listing (unwrap! (get-listing id) err-unknown-listing))
 		)
-		(asserts! (is-eq tx-sender (get maker listing)) err-not-the-maker)
+		(asserts! (is-eq contract-caller (get maker listing)) err-not-the-maker)
 		(map-set listings {id: id} (merge listing {name: new-name}))
 		(ok true)
 	)
@@ -100,7 +100,7 @@ below.
 			;; No meaningful error code is emitted if the unwrap fails.
 			(listing (unwrap-panic (get-listing id)))
 		)
-		(asserts! (is-eq tx-sender (get maker listing)) err-not-the-maker)
+		(asserts! (is-eq contract-caller (get maker listing)) err-not-the-maker)
 		(map-set listings {id: id} (merge listing {name: new-name}))
 		(ok true)
 	)
@@ -124,7 +124,7 @@ For example:
 
 ```Clarity,{"nonplayable":true}
 (define-public (update-name (new-name (string-ascii 50)))
-	(if (is-eq tx-sender contract-owner)
+	(if (is-eq contract-caller contract-owner)
 		(ok (var-set contract-name new-name))
 		err-not-contract-owner
 	)
@@ -136,7 +136,7 @@ Can be rewritten to:
 ```Clarity,{"nonplayable":true}
 (define-public (update-name (new-name (string-ascii 50)))
 	(begin
-		(asserts! (is-eq tx-sender contract-owner) err-not-contract-owner)
+		(asserts! (is-eq contract-caller contract-owner) err-not-contract-owner)
 		(ok (var-set contract-name new-name))
 	)
 )
@@ -200,7 +200,7 @@ Here is a real transfer function found in a mainnet contract:
 
 ```Clarity,{"nonplayable":true}
 (define-public (transfer (token-id uint) (sender principal) (recipient principal))
-	(if (and (is-eq tx-sender sender))
+	(if (and (is-eq contract-caller sender))
 		(match (nft-transfer? my-nft token-id sender recipient)
 			success (ok success)
 			error (err error))
@@ -214,7 +214,7 @@ Refactoring the `if` and `match`, we are left with just this:
 ```Clarity,{"nonplayable":true}
 (define-public (transfer (token-id uint) (sender principal) (recipient principal))
 	(begin
-		(asserts! (is-eq tx-sender sender) (err u500))
+		(asserts! (is-eq contract-caller sender) (err u500))
 		(nft-transfer? my-nft token-id sender recipient)
 	)
 )


### PR DESCRIPTION
Changing instances of control flow and authentication mechanisms to use `contract-caller` instead of `tx-sender` to avoid the malicious contract vulnerability.